### PR TITLE
Update grade.sh

### DIFF
--- a/grade.sh
+++ b/grade.sh
@@ -10,9 +10,9 @@ function run_wasm {
     shift
     local run_args=$@
     if [ -z "$run_args" ]; then
-      local output=$(timeout 5 wasm-vm "$wasm_file" 2>&1)
+      local output=$(timeout 5 ./wasm-vm "$wasm_file" 2>&1)
     else
-      local output=$(timeout 5 wasm-vm -a $run_args "$wasm_file" 2>&1)
+      local output=$(timeout 5 ./wasm-vm -a $run_args "$wasm_file" 2>&1)
     fi
     if [ $? -ne 0 ]; then
       echo "timeout"


### PR DESCRIPTION
Previously the script requires the `build` directory to be on the PATH. Otherwise, an error like this will be thrown.
```
#### Test 1 ####
call0 (run_args: (void)) ... fail!
  Expected output:
  -------------------
89
  -------------------
  Actual output:
  -------------------
timeout: failed to run command ‘wasm-vm’: No such file or directory
  -------------------
```
This PR should remove this requirement.

**Alternative change:**
Specify the requirement in the README file.